### PR TITLE
Enhance video menu with GPT cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # streaming-video-downloader
 Cross-platform streaming video downloader built with Python and Kivy.
+
+## Funcionalidades
+
+- Download de vídeos do YouTube, TikTok e Instagram.
+- Corte manual de vídeos informando o tempo de início e fim no formato `HH:MM:SS`.
+- Tela de configuração para salvar a chave da API do ChatGPT.
+- Geração automática de sugestões de cortes utilizando o ChatGPT a partir de uma transcrição.


### PR DESCRIPTION
## Summary
- update README with new features
- enable dotenv loading and add helper for HH:MM:SS parsing
- improve cut screen layout and use HH:MM:SS inputs
- add configuration screen for ChatGPT API key
- add automatic cut screen with GPT integration and suggestions

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc0bd1f54832581a4c7cb9a3d4e8b