### PR TITLE
Fix recursion in show_loading causing crash

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -400,8 +400,6 @@ class CutScreen(Screen):
             self._loading = ModalView(size_hint=(0.5, 0.3), auto_dismiss=False)
             self._loading.add_widget(layout)
         self._loading.open()
-
-        self.show_loading()
     def hide_loading(self, *_):
         if self._loading is not None:
             self._loading.dismiss()


### PR DESCRIPTION
## Summary
- fix infinite recursion when displaying the loading modal during video cutting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de05476588325ac5347f21f2757f6