### PR TITLE
Fix resize crash with Pillow 10+

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -44,6 +44,12 @@ logging.basicConfig(
 import yt_dlp
 import instaloader
 from moviepy.editor import VideoFileClip
+from PIL import Image
+
+# Pillow >=10 removed the Image.ANTIALIAS constant used by MoviePy.
+# Provide a fallback for compatibility with older MoviePy versions.
+if not hasattr(Image, "ANTIALIAS"):
+    Image.ANTIALIAS = Image.Resampling.LANCZOS
 
 try:
     from tkinter import filedialog, Tk


### PR DESCRIPTION
## Summary
- ensure compatibility between MoviePy and Pillow 10+

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685de33616bc8325869d764c605bd310