### PR TITLE
Add VIDEO_HWACCEL flag for hardware encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ TIKTOK_PASSWORD=<senha>
 ```
 
 Essas informações são utilizadas pelos módulos de upload em `uploader/`.
+- Defina `VIDEO_HWACCEL=1` para habilitar exportação de vídeos utilizando um
+  codec de hardware (ex.: `h264_nvenc`). É necessário ter o FFmpeg compilado
+  com suporte à aceleração da GPU utilizada.
 - Transcrição automática agora utiliza a versão open-source do modelo `whisper`.
 
 Para utilizar a transcrição automática, instale os pacotes listados em `requirements.txt`, em especial o `openai-whisper`.
@@ -31,3 +34,5 @@ Para utilizar a transcrição automática, instale os pacotes listados em `requi
 
 - Os cortes gerados assumem as seguintes resoluções padronizadas: YouTube 1280x720 (16:9), TikTok 720x1280 (9:16) e Instagram Stories 1080x1920 (9:16).
 - Pré-visualização das sugestões com possibilidade de ajuste manual e salvamento do corte.
+- Para usar `VIDEO_HWACCEL`, o FFmpeg deve ser compilado com o codec
+  de aceleração correspondente (ex.: suporte ao NVENC para `h264_nvenc`).

--- a/cortar_varios_videos.py
+++ b/cortar_varios_videos.py
@@ -4,6 +4,8 @@ from moviepy.editor import VideoFileClip
 import datetime
 import os
 
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
+
 def escolher_video():
     input_file = filedialog.askopenfilename(title="Selecione o arquivo de vídeo")
     if input_file:
@@ -40,7 +42,7 @@ def cortar_videos():
 
                 video = VideoFileClip(input_file).subclip(start_time, end_time)
                 output_file = os.path.join(pasta_saida, f"corte_{i}.mp4")
-                video.write_videofile(output_file, codec="libx264", audio_codec="aac")
+                video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
             except Exception as e:
                 messagebox.showerror("Erro", f"Erro ao processar o intervalo '{intervalo}': {e}")
                 continue

--- a/cortarvideo.py
+++ b/cortarvideo.py
@@ -2,6 +2,10 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from moviepy.editor import VideoFileClip
 import datetime
+import os
+
+# Select hardware accelerated codec when VIDEO_HWACCEL is set
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
 
 def escolher_video():
     input_file = filedialog.askopenfilename(title="Selecione o arquivo de vídeo")
@@ -65,7 +69,7 @@ def cortar_video():
 
     try:
         video = VideoFileClip(input_file).subclip(start_time, end_time)
-        video.write_videofile(output_file, codec="libx264", audio_codec="aac")
+        video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
         messagebox.showinfo("Sucesso", f"Vídeo cortado salvo como {output_file}")
     except Exception as e:
         messagebox.showerror("Erro", f"Erro ao cortar o vídeo: {e}")

--- a/cortarvideoLaterais.py
+++ b/cortarvideoLaterais.py
@@ -3,6 +3,9 @@ from tkinter import filedialog, messagebox, ttk
 from moviepy.editor import VideoFileClip
 from moviepy.video.fx.all import crop
 from tqdm import tqdm
+import os
+
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
 
 class VideoCropperApp:
     def __init__(self, root):
@@ -62,7 +65,7 @@ class VideoCropperApp:
             self.root.update_idletasks()
 
         # Salve o vídeo cortado
-        cropped_video.write_videofile(self.output_video_path, codec="libx264")
+        cropped_video.write_videofile(self.output_video_path, codec=VIDEO_CODEC)
 
         messagebox.showinfo("Concluído", "O vídeo foi cortado e salvo com sucesso!")
         self.progress_label.config(text="Processo concluído!")

--- a/cortarvideoNoMeio.py
+++ b/cortarvideoNoMeio.py
@@ -1,6 +1,9 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox
 from moviepy.editor import VideoFileClip, vfx
+import os
+
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
 
 def escolher_video():
     input_file = filedialog.askopenfilename(title="Selecione o arquivo de vídeo")
@@ -29,8 +32,8 @@ def cortar_verticalmente():
         video_esquerda = video.crop(x1=0, y1=0, x2=metade_largura, y2=height)
         video_direita = video.crop(x1=metade_largura, y1=0, x2=width, y2=height)
 
-        video_esquerda.write_videofile(output_file_esquerda, codec="libx264", audio_codec="aac")
-        video_direita.write_videofile(output_file_direita, codec="libx264", audio_codec="aac")
+        video_esquerda.write_videofile(output_file_esquerda, codec=VIDEO_CODEC, audio_codec="aac")
+        video_direita.write_videofile(output_file_direita, codec=VIDEO_CODEC, audio_codec="aac")
 
         messagebox.showinfo("Sucesso", f"Vídeos cortados salvos como {output_file_esquerda} e {output_file_direita}")
     except Exception as e:

--- a/cortarvideo_teste.py
+++ b/cortarvideo_teste.py
@@ -2,6 +2,9 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from moviepy.editor import VideoFileClip
 import datetime
+import os
+
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
 
 def escolher_video():
     input_file = filedialog.askopenfilename(title="Selecione o arquivo de vídeo")
@@ -69,7 +72,7 @@ def cortar_video():
 
     try:
         video = VideoFileClip(input_file).subclip(start_time, end_time)
-        video.write_videofile(output_file, codec="libx264", audio_codec="aac")
+        video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
         messagebox.showinfo("Sucesso", f"Vídeo cortado salvo como {output_file}")
     except Exception as e:
         messagebox.showerror("Erro", f"Erro ao cortar o vídeo: {e}")

--- a/criarVideoUmDebaixoDoOutro.py
+++ b/criarVideoUmDebaixoDoOutro.py
@@ -4,6 +4,9 @@ from tkinter import filedialog, messagebox
 from PIL import Image, ImageTk
 import threading
 import numpy as np
+import os
+
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
 
 def resize_with_lanczos(image, new_size):
     pil_image = Image.fromarray(image)
@@ -56,7 +59,7 @@ def create_tiktok_video(video_top_path, video_bottom_path, output_path, audio_fr
             final_clip = final_clip.set_audio(video_bottom.audio)
 
         # Exportar vídeo final
-        final_clip.write_videofile(output_path, codec="libx264", audio_codec="aac")
+        final_clip.write_videofile(output_path, codec=VIDEO_CODEC, audio_codec="aac")
 
         update_progress(100)
     except Exception as e:

--- a/video_menu.py
+++ b/video_menu.py
@@ -13,6 +13,8 @@ import threading
 import logging
 from pathlib import Path
 
+VIDEO_CODEC = "h264_nvenc" if os.getenv("VIDEO_HWACCEL") else "libx264"
+
 from kivy.app import App
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
@@ -450,7 +452,7 @@ class CutScreen(Screen):
             video_codec = "libvpx"
             audio_codec = "libvorbis"
         else:
-            video_codec = "libx264"
+            video_codec = VIDEO_CODEC
             audio_codec = "aac"
 
         clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
@@ -776,7 +778,7 @@ class AutoCutScreen(Screen):
             video_codec = "libvpx"
             audio_codec = "libvorbis"
         else:
-            video_codec = "libx264"
+            video_codec = VIDEO_CODEC
             audio_codec = "aac"
 
         clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
@@ -827,7 +829,7 @@ class AutoCutScreen(Screen):
             final = concatenate_videoclips(clips)
             out_dir = os.path.dirname(paths[0])
             out_file = os.path.join(out_dir, f"merged_{datetime.now().strftime('%H-%M-%S')}.mp4")
-            final.write_videofile(out_file, codec="libx264", audio_codec="aac")
+            final.write_videofile(out_file, codec=VIDEO_CODEC, audio_codec="aac")
             for clip in clips:
                 clip.close()
             final.close()


### PR DESCRIPTION
## Summary
- let multiple scripts use hardware accelerated codec when `VIDEO_HWACCEL` is set
- document the new flag and FFmpeg requirements in `README.md`

## Testing
- `python -m py_compile cortarvideo.py cortarvideo_teste.py cortarvideoLaterais.py cortarvideoNoMeio.py cortar_varios_videos.py criarVideoUmDebaixoDoOutro.py video_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0455fed483259f265aef7ba9a0e6