### PR TITLE
Add GPT-powered post screen

### DIFF
--- a/uploader/facebook.py
+++ b/uploader/facebook.py
@@ -1,0 +1,6 @@
+"""Placeholder module for Facebook uploads."""
+
+
+def upload_video(*_args, **_kwargs):
+    """Facebook does not provide an official upload API."""
+    raise NotImplementedError("No official Facebook upload API available")

--- a/uploader/x.py
+++ b/uploader/x.py
@@ -1,0 +1,6 @@
+"""Placeholder module for X (Twitter) uploads."""
+
+
+def upload_video(*_args, **_kwargs):
+    """X/Twitter does not provide an official upload API."""
+    raise NotImplementedError("No official X upload API available")


### PR DESCRIPTION
## Summary
- replace old upload popup with a post screen opener
- generate per-platform descriptions via GPT and allow editing
- add PostScreen to select a file and post to social networks
- include placeholder upload modules for Facebook and X

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e0f807d5c8325a77e334e4ac41333