### PR TITLE
Use segment times in GPT prompt

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -848,7 +848,11 @@ class AutoCutScreen(Screen):
         try:
             model = whisper.load_model("base")
             result = model.transcribe(path, fp16=False)
-            transcript = result.get("text", "")
+            segments = result["segments"]
+            transcript = "\n".join(
+                f"{seconds_to_hms(s['start'])}-{seconds_to_hms(s['end'])} {s['text'].strip()}"
+                for s in segments
+            )
             Clock.schedule_once(lambda *_: self.update_progress(50))
 
             clip = VideoFileClip(path)


### PR DESCRIPTION
## Summary
- build time-coded transcripts from `result['segments']`
- send these transcripts when generating GPT suggestions

## Testing
- `python -m py_compile video_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_685f556873808325aeb370148b0fdce2