### PR TITLE
Handle GPT JSON responses

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -842,6 +842,7 @@ class AutoCutScreen(Screen):
                 + duration
                 + ". Use quantos cortes forem relevantes.\n"
                 + transcript
+                + "\nReturn a JSON array of objects with `title`, `description`, `start`, `end`."
             )
 
             completion = openai.chat.completions.create(
@@ -851,7 +852,12 @@ class AutoCutScreen(Screen):
             )
             text = completion.choices[0].message.content
             logging.info("Prompt:\n%s\nResponse preview:\n%s", prompt, text[:200])
-            suggestions = parse_suggestions(text)
+            try:
+                suggestions = json.loads(text)
+            except Exception as exc:
+                logging.exception("JSON parsing failed")
+                Clock.schedule_once(lambda *_, exc=exc: self._generate_failed(exc))
+                return
             date_dir = Path("videos") / datetime.now().strftime("%Y-%m-%d")
             date_dir.mkdir(parents=True, exist_ok=True)
             with open(date_dir / "suggestions.json", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- update OpenAI prompt to request JSON with title, description, start and end
- parse the returned content with `json.loads` and handle failures

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f51058828832589f0cadccb64bb35