### PR TITLE
Improve GPT logging

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -879,8 +879,9 @@ class AutoCutScreen(Screen):
             )
             text = completion.choices[0].message.content
             finish_reason = completion.choices[0].finish_reason
+            usage = getattr(completion, "usage", None)
             logging.info(
-                "Prompt:\n%s\nResponse preview:\n%s", prompt, text[:200]
+                "Prompt:\n%s\nResponse:\n%s\nUsage: %s", prompt, text, usage
             )
             if finish_reason and finish_reason != "stop":
                 raise RuntimeError(


### PR DESCRIPTION
## Summary
- show the full ChatGPT response in logs
- log token usage from API responses for easier cost analysis

## Testing
- `python -m py_compile video_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_686022b07eec8325a4d5552a62b67d64