### PR TITLE
Fix log to keep preview and full response

### DIFF
--- a/video_menu.py
+++ b/video_menu.py
@@ -881,6 +881,9 @@ class AutoCutScreen(Screen):
             finish_reason = completion.choices[0].finish_reason
             usage = getattr(completion, "usage", None)
             logging.info(
+                "Prompt:\n%s\nResponse preview:\n%s", prompt, text[:200]
+            )
+            logging.info(
                 "Prompt:\n%s\nResponse:\n%s\nUsage: %s", prompt, text, usage
             )
             if finish_reason and finish_reason != "stop":


### PR DESCRIPTION
## Summary
- keep preview log when adding full API response

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860273c6e088325bd12fcba394d8927