### PR TITLE
Ensure clips are closed after saving

### DIFF
--- a/cortar_varios_videos.py
+++ b/cortar_varios_videos.py
@@ -43,6 +43,7 @@ def cortar_videos():
                 video = VideoFileClip(input_file).subclip(start_time, end_time)
                 output_file = os.path.join(pasta_saida, f"corte_{i}.mp4")
                 video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
+                video.close()
             except Exception as e:
                 messagebox.showerror("Erro", f"Erro ao processar o intervalo '{intervalo}': {e}")
                 continue

--- a/cortarvideo.py
+++ b/cortarvideo.py
@@ -70,6 +70,7 @@ def cortar_video():
     try:
         video = VideoFileClip(input_file).subclip(start_time, end_time)
         video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
+        video.close()
         messagebox.showinfo("Sucesso", f"Vídeo cortado salvo como {output_file}")
     except Exception as e:
         messagebox.showerror("Erro", f"Erro ao cortar o vídeo: {e}")

--- a/cortarvideoLaterais.py
+++ b/cortarvideoLaterais.py
@@ -66,6 +66,8 @@ class VideoCropperApp:
 
         # Salve o vídeo cortado
         cropped_video.write_videofile(self.output_video_path, codec=VIDEO_CODEC)
+        cropped_video.close()
+        video.close()
 
         messagebox.showinfo("Concluído", "O vídeo foi cortado e salvo com sucesso!")
         self.progress_label.config(text="Processo concluído!")

--- a/cortarvideoNoMeio.py
+++ b/cortarvideoNoMeio.py
@@ -34,6 +34,9 @@ def cortar_verticalmente():
 
         video_esquerda.write_videofile(output_file_esquerda, codec=VIDEO_CODEC, audio_codec="aac")
         video_direita.write_videofile(output_file_direita, codec=VIDEO_CODEC, audio_codec="aac")
+        video_esquerda.close()
+        video_direita.close()
+        video.close()
 
         messagebox.showinfo("Sucesso", f"Vídeos cortados salvos como {output_file_esquerda} e {output_file_direita}")
     except Exception as e:

--- a/cortarvideo_teste.py
+++ b/cortarvideo_teste.py
@@ -73,6 +73,7 @@ def cortar_video():
     try:
         video = VideoFileClip(input_file).subclip(start_time, end_time)
         video.write_videofile(output_file, codec=VIDEO_CODEC, audio_codec="aac")
+        video.close()
         messagebox.showinfo("Sucesso", f"Vídeo cortado salvo como {output_file}")
     except Exception as e:
         messagebox.showerror("Erro", f"Erro ao cortar o vídeo: {e}")

--- a/criarVideoUmDebaixoDoOutro.py
+++ b/criarVideoUmDebaixoDoOutro.py
@@ -60,6 +60,9 @@ def create_tiktok_video(video_top_path, video_bottom_path, output_path, audio_fr
 
         # Exportar vídeo final
         final_clip.write_videofile(output_path, codec=VIDEO_CODEC, audio_codec="aac")
+        final_clip.close()
+        video_top.close()
+        video_bottom.close()
 
         update_progress(100)
     except Exception as e:

--- a/video_menu.py
+++ b/video_menu.py
@@ -683,6 +683,7 @@ class CutScreen(Screen):
             audio_codec = "aac"
 
         clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
+        clip.close()
 
         Clock.schedule_once(lambda *_: self.update_progress(100))
         Clock.schedule_once(
@@ -1079,6 +1080,7 @@ class AutoCutScreen(Screen):
             audio_codec = "aac"
 
         clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
+        clip.close()
         self.cut_counter += 1
         self.generated_cuts.append(out_file)
         Clock.schedule_once(lambda *_: self.show_popup("Sucesso", "Corte gerado"))


### PR DESCRIPTION
## Summary
- release resources after writing video files by calling `close()`
- apply this fix in `CutScreen`, `AutoCutScreen` and several utility scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686039e098908325b2bfce43b321399b