### PR TITLE
Fix output path when cutting videos

### DIFF
--- a/video_cut_utils.py
+++ b/video_cut_utils.py
@@ -22,9 +22,17 @@ def parse_time(hms: str) -> float:
 
 def cut_video(input_path: str, output_path: str, start: float, end: float) -> None:
     """Cut ``input_path`` between ``start`` and ``end`` seconds and save to ``output_path``."""
+    output_path = os.path.abspath(output_path)
+    temp_audio = os.path.splitext(output_path)[0] + "_temp_audio.m4a"
     with VideoFileClip(input_path) as src:
         sub = src.subclip(start, end)
-        sub.write_videofile(output_path, codec=VIDEO_CODEC, audio_codec="aac")
+        sub.write_videofile(
+            output_path,
+            codec=VIDEO_CODEC,
+            audio_codec="aac",
+            temp_audiofile=temp_audio,
+            remove_temp=True,
+        )
         sub.close()
 
 def cut_vertical_halves(input_path: str, left_output: str, right_output: str) -> None:

--- a/video_menu.py
+++ b/video_menu.py
@@ -670,9 +670,10 @@ class CutScreen(Screen):
         end_str = seconds_to_hms(end).replace(":", "-")
         base_dir = os.path.dirname(path)
         original_name = os.path.basename(path)
-        out_file = os.path.join(
-            base_dir, f"corte_{start_str}_{end_str}_{original_name}"
+        out_file = os.path.abspath(
+            os.path.join(base_dir, f"corte_{start_str}_{end_str}_{original_name}")
         )
+        temp_audio = os.path.splitext(out_file)[0] + "_temp_audio.m4a"
 
         ext = os.path.splitext(out_file)[1].lower()
         if ext == ".webm":
@@ -682,7 +683,13 @@ class CutScreen(Screen):
             video_codec = VIDEO_CODEC
             audio_codec = "aac"
 
-        clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
+        clip.write_videofile(
+            out_file,
+            codec=video_codec,
+            audio_codec=audio_codec,
+            temp_audiofile=temp_audio,
+            remove_temp=True,
+        )
         clip.close()
 
         Clock.schedule_once(lambda *_: self.update_progress(100))
@@ -1067,10 +1074,13 @@ class AutoCutScreen(Screen):
         end_str = seconds_to_hms(end)
         out_dir = _get_platform_dir("gpt")
         original_name = os.path.basename(path)
-        out_file = os.path.join(
-            out_dir,
-            f"corte_{self.cut_counter}_gpt_{start_str.replace(':', '-')}_{end_str.replace(':', '-')}_{original_name}",
+        out_file = os.path.abspath(
+            os.path.join(
+                out_dir,
+                f"corte_{self.cut_counter}_gpt_{start_str.replace(':', '-')}_{end_str.replace(':', '-')}_{original_name}",
+            )
         )
+        temp_audio = os.path.splitext(out_file)[0] + "_temp_audio.m4a"
         ext = os.path.splitext(out_file)[1].lower()
         if ext == ".webm":
             video_codec = "libvpx"
@@ -1079,7 +1089,13 @@ class AutoCutScreen(Screen):
             video_codec = VIDEO_CODEC
             audio_codec = "aac"
 
-        clip.write_videofile(out_file, codec=video_codec, audio_codec=audio_codec)
+        clip.write_videofile(
+            out_file,
+            codec=video_codec,
+            audio_codec=audio_codec,
+            temp_audiofile=temp_audio,
+            remove_temp=True,
+        )
         clip.close()
         self.cut_counter += 1
         self.generated_cuts.append(out_file)


### PR DESCRIPTION
## Summary
- ensure output paths are absolute and temp audio is kept in same folder
- update cut functions to use absolute paths and temp audio files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686050a24c2c832588565efd4728aa95